### PR TITLE
uv: migrated from pip to uv

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,28 +11,25 @@ on:
 jobs:
   pylint:
     runs-on: ubuntu-22.04
+    container:
+      image: python:3.13-alpine3.22
     permissions:
       contents: write
     steps:
       - name: Initial checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
 
-      - name: Setup python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
+      - name: Install uv
+        run: apk add curl && curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: Install dependencies
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install pylint ruff
+          uv sync --extra linter
 
       - name: Run linter
         run: |
-          ruff check . --select=E231 --fix --preview
-          find . -name '*.py' | xargs pylint --rcfile=.pylintrc
+          uv run ruff check . --select=E231 --fix --preview
+          find . -name '*.py' | grep -v .venv | xargs uv run pylint --rcfile=.pylintrc
 
       - name: Update branch with linter changes
         run: |
@@ -51,20 +48,18 @@ jobs:
   api-tests:
     needs: pylint
     runs-on: ubuntu-22.04
-    env:
-      RIOT_API_KEY: ${{ secrets.RIOT_API_KEY }}
-      MONGODB_URL: ${{ secrets.MONGODB_URL }}
-      POSTGRES_DB_URL: ${{ secrets.POSTGRES_DB_URL }}
     container:
       image: python:3.13-alpine3.22
     steps:
       - name: Initial checkout
         uses: actions/checkout@v4
 
+      - name: Install uv
+        run: apk add curl && curl -LsSf https://astral.sh/uv/install.sh | sh
+
       - name: Install dependencies
         run: |
-          python3 -m pip install -r api/requirements.txt
+          uv sync --extra test --extra api
 
       - name: Run tests
-        run: pytest
-        working-directory: api/src/tests
+        run: uv run pytest api/src/tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,13 @@ on:
 jobs:
   pylint:
     runs-on: ubuntu-22.04
+    strategy:
+      # to allow several python version (airflow, api, etc.)
+      matrix:
+        python-version:
+          - 3.13
     container:
-      image: python:3.13-alpine3.22
+      image: python:${{ matrix.python-version }}-alpine3.22
     permissions:
       contents: write
     steps:
@@ -48,8 +53,13 @@ jobs:
   api-tests:
     needs: pylint
     runs-on: ubuntu-22.04
+    strategy:
+      # to allow several python version (airflow, api, etc.)
+      matrix:
+        python-version:
+          - 3.13
     container:
-      image: python:3.13-alpine3.22
+      image: python:${{ matrix.python-version }}-alpine3.22
     steps:
       - name: Initial checkout
         uses: actions/checkout@v4

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,6 @@
 [MASTER]
-ignore=.github
+ignore=.github,.venv,venv
+ignore-patterns=.*\.egg-info,.*\.pytest_cache,.*\.venv
 max-line-length=88
 
 [MESSAGES CONTROL]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,14 +1,22 @@
 FROM python:3.13-alpine3.22 AS base
 
+WORKDIR /workspace
 # copy installation files
-COPY requirements.txt /tmp/requirements.txt
+COPY pyproject.toml .
 
 USER root
 
-RUN apk add curl && python3 -m pip install -r /tmp/requirements.txt --break-system-packages && rm /tmp/requirements.txt
+RUN apk add curl && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh
 
-WORKDIR /workspace
+# adding uv to PATH
+ENV PATH="/root/.local/bin:${PATH}"
+
+RUN uv sync --extra api
+
 # copy service files
-COPY src /workspace/src/
+COPY api/src /workspace/src/
 
 WORKDIR /workspace/src
+
+ENTRYPOINT ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080", "--reload"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,8 +6,9 @@ include:
 
 services:
   api:
-    build: api/
-    entrypoint: uvicorn main:app --host 0.0.0.0 --port 8080 --reload
+    build:
+      context: . # to allow copying the pyproject.toml
+      dockerfile: api/Dockerfile
     volumes:
       - ./api/src:/workspace/src
     # don't start if overfast api hasn't started yet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+name = "nitz"
+version = "0.1.0"
+description = "nitz"
+readme = "README.md"
+requires-python = ">=3.13"
+
+[project.optional-dependencies]
+api = [
+    "beautifulsoup4==4.13.3",
+    "fastapi[standard]==0.115.13",
+    "requests",
+    "lxml[html_clean]",
+    "requests-html",
+    "pyppeteer",
+    "cloudscraper",
+    "aiohttp",
+    "pymongo",
+    "sqlalchemy",
+    "httpx"
+]
+
+test = [
+    "pytest"
+]
+
+linter = [
+    "pylint",
+    "ruff"
+]


### PR DESCRIPTION
- using pyproject.toml instead of requirements.txt per service/component
- using root dir as context in api image build process
- changed installation commands in dockerfile and github actions workflows to uv
- added api, test, linter optional dependencies
- the pyproject.toml file allows better organization of dependencies across services and/or components, define python version, managing configurations and building custom libraries